### PR TITLE
Fix Coolify Lands: check for empty strings as well as null

### DIFF
--- a/libs/src/core/Deck.java
+++ b/libs/src/core/Deck.java
@@ -73,7 +73,8 @@ public class Deck {
 		String[] coolSets = {"uh","guru","al","zen"};
 		for(int i = cardList.size()-1; i >= 0; i--){
 			Card card = cardList.get(i);
-			if(card.set == null && card.language == null && card.printing == null){
+			if((card.set == null || card.set.isEmpty()) && (card.language == null || card.language.isEmpty())
+					&& (card.printing == null || card.printing.isEmpty())) {
 				for(String basicName : basics){
 					if(card.name.equalsIgnoreCase(basicName)){
 						int[][] newAmts = new int[card.amounts.length][coolSets.length];


### PR DESCRIPTION
This fixes issue #6 that I just created.  It seems that card.set, etc are actually getting set to an empty string instead of null which was not being checked.  This caused the coolify logic to be skipped.