### PR TITLE
Full Art Basics

### DIFF
--- a/frogtown.js
+++ b/frogtown.js
@@ -54,7 +54,9 @@ exports.HandleDeck = function(reqObj, success, error){
 	var hiddenURL = clean(req.body.hiddenURL);
 	var compression = clean(req.body.compression);
 	var deckName = clean(req.body.name, true);
-	var coolifyBasic = !!req.body.coolify;
+	var test = true;
+	var coolifyBasic = clean(req.body.coolify);
+	var artifyBasic = clean(req.body.artify);
 
 	console.log('Handling deck...');
 
@@ -98,6 +100,7 @@ exports.HandleDeck = function(reqObj, success, error){
   client.write(backURL + '\r\n');
   client.write(hiddenURL + '\r\n');
   client.write(coolifyBasic + '\r\n');
+  client.write(artifyBasic +'\r\n');
   client.write(compression + '\r\n');
   client.write(decklist + '\r\n');
   client.write('ENDDECK\r\n');

--- a/frogtown.js
+++ b/frogtown.js
@@ -54,7 +54,6 @@ exports.HandleDeck = function(reqObj, success, error){
 	var hiddenURL = clean(req.body.hiddenURL);
 	var compression = clean(req.body.compression);
 	var deckName = clean(req.body.name, true);
-	var test = true;
 	var coolifyBasic = clean(req.body.coolify);
 	var artifyBasic = clean(req.body.artify);
 

--- a/libs/files.txt
+++ b/libs/files.txt
@@ -12,3 +12,4 @@ libs/src/utils/cardretrieval/CardRetriever.java
 libs/src/utils/cardretrieval/GathererRetriever.java
 libs/src/utils/cardretrieval/MagicCardsInfoRetriever.java
 libs/src/utils/cardretrieval/MythicSpoilerRetriever.java
+libs/src/helpers/Pair.java

--- a/libs/src/core/Config.java
+++ b/libs/src/core/Config.java
@@ -90,26 +90,26 @@ public class Config {
 						harNameObj.get("easy").getAsString()
 				};
 			}
-			
+						
 			JsonArray fullArtLandConfigArr = configObject.getAsJsonArray("fullArtLands");
 			fullArtMap = new HashMap<String, ArrayList<Pair<String, String>>>();
 			for(int i = 0; i < fullArtLandConfigArr.size(); i++) {
-				ArrayList<Pair<String, String>> pairList = new ArrayList<Pair<String, String>>();
+				ArrayList<Pair<String, String>> printingList = new ArrayList<Pair<String, String>>();
 				
 				String landName = fullArtLandConfigArr.get(i).getAsJsonObject().get("landType").getAsString();
-				JsonArray cardsArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("cards").getAsJsonArray();
+				JsonArray printingInfoArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("printInfo").getAsJsonArray(); //array of printInfos.  PrintInfos have sets and associated print numbers 
 
-				for(int j = 0; j < cardsArr.size(); j++) {
-					JsonObject setObj = cardsArr.get(j).getAsJsonObject(); //printings are grouped by set
+				for(int j = 0; j < printingInfoArr.size(); j++) {
+					JsonObject setObj = printingInfoArr.get(j).getAsJsonObject(); //printInfo's set
 					String setName = setObj.get("set").getAsString();
-					JsonArray printingsArr = setObj.getAsJsonArray("printings"); //array of printings for each set
-					for(int k = 0; k < printingsArr.size(); k++) {
-						String printing = printingsArr.get(k).getAsString();
-						Pair<String, String> pair = new Pair<String, String>(setName, printing);
-						pairList.add(pair);
+					JsonArray printNumberArr = setObj.getAsJsonArray("printNumbers"); //printInfo's arr of print numbers
+					for(int k = 0; k < printNumberArr.size(); k++) {
+						String printNumber = printNumberArr.get(k).getAsString();
+						Pair<String, String> printing = new Pair<String, String>(setName, printNumber); //each printing is defined by a set and printNumber pair
+						printingList.add(printing);
 					}
 				}
-				fullArtMap.put(landName, pairList);
+				fullArtMap.put(landName, printingList);
 			}
 		}catch(Exception e){
 			e.printStackTrace();

--- a/libs/src/core/Config.java
+++ b/libs/src/core/Config.java
@@ -90,26 +90,26 @@ public class Config {
 						harNameObj.get("easy").getAsString()
 				};
 			}
-						
+			
 			JsonArray fullArtLandConfigArr = configObject.getAsJsonArray("fullArtLands");
 			fullArtMap = new HashMap<String, ArrayList<Pair<String, String>>>();
 			for(int i = 0; i < fullArtLandConfigArr.size(); i++) {
-				ArrayList<Pair<String, String>> printingList = new ArrayList<Pair<String, String>>();
+				ArrayList<Pair<String, String>> pairList = new ArrayList<Pair<String, String>>();
 				
 				String landName = fullArtLandConfigArr.get(i).getAsJsonObject().get("landType").getAsString();
-				JsonArray printingInfoArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("printInfo").getAsJsonArray(); //array of printInfos.  PrintInfos have sets and associated print numbers 
+				JsonArray cardsArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("cards").getAsJsonArray();
 
-				for(int j = 0; j < printingInfoArr.size(); j++) {
-					JsonObject setObj = printingInfoArr.get(j).getAsJsonObject(); //printInfo's set
+				for(int j = 0; j < cardsArr.size(); j++) {
+					JsonObject setObj = cardsArr.get(j).getAsJsonObject(); //printings are grouped by set
 					String setName = setObj.get("set").getAsString();
-					JsonArray printNumberArr = setObj.getAsJsonArray("printNumbers"); //printInfo's arr of print numbers
-					for(int k = 0; k < printNumberArr.size(); k++) {
-						String printNumber = printNumberArr.get(k).getAsString();
-						Pair<String, String> printing = new Pair<String, String>(setName, printNumber); //each printing is defined by a set and printNumber pair
-						printingList.add(printing);
+					JsonArray printingsArr = setObj.getAsJsonArray("printings"); //array of printings for each set
+					for(int k = 0; k < printingsArr.size(); k++) {
+						String printing = printingsArr.get(k).getAsString();
+						Pair<String, String> pair = new Pair<String, String>(setName, printing);
+						pairList.add(pair);
 					}
 				}
-				fullArtMap.put(landName, printingList);
+				fullArtMap.put(landName, pairList);
 			}
 		}catch(Exception e){
 			e.printStackTrace();

--- a/libs/src/core/Config.java
+++ b/libs/src/core/Config.java
@@ -94,22 +94,22 @@ public class Config {
 			JsonArray fullArtLandConfigArr = configObject.getAsJsonArray("fullArtLands");
 			fullArtMap = new HashMap<String, ArrayList<Pair<String, String>>>();
 			for(int i = 0; i < fullArtLandConfigArr.size(); i++) {
-				ArrayList<Pair<String, String>> pairList = new ArrayList<Pair<String, String>>();
+				ArrayList<Pair<String, String>> printingList = new ArrayList<Pair<String, String>>();
 				
 				String landName = fullArtLandConfigArr.get(i).getAsJsonObject().get("landType").getAsString();
-				JsonArray cardsArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("cards").getAsJsonArray();
+				JsonArray printingInfoArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("printInfo").getAsJsonArray(); //array of printInfos.  PrintInfos have sets and associated print numbers 
 
-				for(int j = 0; j < cardsArr.size(); j++) {
-					JsonObject setObj = cardsArr.get(j).getAsJsonObject(); //printings are grouped by set
+				for(int j = 0; j < printingInfoArr.size(); j++) {
+					JsonObject setObj = printingInfoArr.get(j).getAsJsonObject(); //printInfo's set
 					String setName = setObj.get("set").getAsString();
-					JsonArray printingsArr = setObj.getAsJsonArray("printings"); //array of printings for each set
-					for(int k = 0; k < printingsArr.size(); k++) {
-						String printing = printingsArr.get(k).getAsString();
-						Pair<String, String> pair = new Pair<String, String>(setName, printing);
-						pairList.add(pair);
+					JsonArray printNumberArr = setObj.getAsJsonArray("printNumbers"); //printInfo's arr of print numbers
+					for(int k = 0; k < printNumberArr.size(); k++) {
+						String printNumber = printNumberArr.get(k).getAsString();
+						Pair<String, String> printing = new Pair<String, String>(setName, printNumber); //each printing is defined by a set and printNumber pair
+						printingList.add(printing);
 					}
 				}
-				fullArtMap.put(landName, pairList);
+				fullArtMap.put(landName, printingList);
 			}
 		}catch(Exception e){
 			e.printStackTrace();

--- a/libs/src/core/Config.java
+++ b/libs/src/core/Config.java
@@ -1,8 +1,12 @@
 package core;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import helpers.Pair;
 import utils.FrogUtils;
 
 public class Config {
@@ -33,6 +37,7 @@ public class Config {
 	public static String[][] hardUrls;
 	public static String[][] hardNameCharacters;
 	public static String[][] mythicErrors;
+	public static Map<String, ArrayList<Pair<String, String>>> fullArtMap;
 	
 	public static boolean LoadConfig(){
 		try{
@@ -48,7 +53,6 @@ public class Config {
 
 			tokenListDir = configObject.getAsJsonPrimitive("tokenListDir").getAsString();
 			//System.out.println("TEST: " + configObject.getAsJsonPrimitive("tokenListDir"));
-			String test = "1" + "2";
 			transformMapDir = configObject.getAsJsonPrimitive("transformMapDir").getAsString();
 
 			hostUrlPrefix = configObject.getAsJsonPrimitive("hostUrlPrefix").getAsString();
@@ -85,6 +89,27 @@ public class Config {
 						harNameObj.get("hard").getAsString(),
 						harNameObj.get("easy").getAsString()
 				};
+			}
+			
+			JsonArray fullArtLandConfigArr = configObject.getAsJsonArray("fullArtLands");
+			fullArtMap = new HashMap<String, ArrayList<Pair<String, String>>>();
+			for(int i = 0; i < fullArtLandConfigArr.size(); i++) {
+				ArrayList<Pair<String, String>> pairList = new ArrayList<Pair<String, String>>();
+				
+				String landName = fullArtLandConfigArr.get(i).getAsJsonObject().get("landType").getAsString();
+				JsonArray cardsArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("cards").getAsJsonArray();
+
+				for(int j = 0; j < cardsArr.size(); j++) {
+					JsonObject setObj = cardsArr.get(j).getAsJsonObject(); //printings are grouped by set
+					String setName = setObj.get("set").getAsString();
+					JsonArray printingsArr = setObj.getAsJsonArray("printings"); //array of printings for each set
+					for(int k = 0; k < printingsArr.size(); k++) {
+						String printing = printingsArr.get(k).getAsString();
+						Pair<String, String> pair = new Pair<String, String>(setName, printing);
+						pairList.add(pair);
+					}
+				}
+				fullArtMap.put(landName, pairList);
 			}
 		}catch(Exception e){
 			e.printStackTrace();

--- a/libs/src/core/Config.java
+++ b/libs/src/core/Config.java
@@ -97,7 +97,7 @@ public class Config {
 				ArrayList<Pair<String, String>> printingList = new ArrayList<Pair<String, String>>();
 				
 				String landName = fullArtLandConfigArr.get(i).getAsJsonObject().get("landType").getAsString();
-				JsonArray printingInfoArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("printInfo").getAsJsonArray(); //array of printInfos.  PrintInfos have sets and associated print numbers 
+				JsonArray printingInfoArr = fullArtLandConfigArr.get(i).getAsJsonObject().get("printingInfo").getAsJsonArray(); //array of printInfos.  PrintInfos have sets and associated print numbers 
 
 				for(int j = 0; j < printingInfoArr.size(); j++) {
 					JsonObject setObj = printingInfoArr.get(j).getAsJsonObject(); //printInfo's set

--- a/libs/src/core/Deck.java
+++ b/libs/src/core/Deck.java
@@ -77,39 +77,41 @@ public class Deck {
 		for (int i = cardList.size() - 1; i >= 0; i-- ) {
 			Card card = cardList.get(i);
 
-			if(fullArtLands.containsKey(card.name)) {
-				ArrayList<Pair<String, String>> pairList = fullArtLands.get(card.name);
-				
-				int[][] newAmts = new int[card.amounts.length][pairList.size()];
-				
-				for(int j= 0; j< card.amounts.length; j++) {
-					for(int k=0; k < card.amounts[j]; k++) {
-						newAmts[j][(int) (Math.random() * pairList.size())]++;
-					}
-				}
-				
-				for (int j = 0; j < newAmts.length; j++) {
-					for (int k = 0; k < newAmts[j].length; k++) {
-						if (newAmts[j][k] == 0)
-							continue;
-	
-						String set = pairList.get(k).getX();
-						String printing = pairList.get(k).getY();
-						String cardKey = Card.getCardKey(card.name, set, printing, null);
-						Card coolBasic = getCard(cardKey);
-						if (coolBasic == null) {
-							coolBasic = new Card();
-							coolBasic.name = card.name;
-							coolBasic.cardKey = cardKey;
-							coolBasic.set = set;
-							coolBasic.printing = printing;
-
-							add(coolBasic);
+			if(FrogUtils.IsNullOrEmpty(card.set) && FrogUtils.IsNullOrEmpty(card.language) && FrogUtils.IsNullOrEmpty(card.printing)){
+				if(fullArtLands.containsKey(card.name)) {
+					ArrayList<Pair<String, String>> pairList = fullArtLands.get(card.name);
+					
+					int[][] newAmts = new int[card.amounts.length][pairList.size()];
+					
+					for(int j= 0; j< card.amounts.length; j++) {
+						for(int k=0; k < card.amounts[j]; k++) {
+							newAmts[j][(int) (Math.random() * pairList.size())]++;
 						}
-						coolBasic.amounts[j] += newAmts[j][k];
 					}
+					
+					for (int j = 0; j < newAmts.length; j++) {
+						for (int k = 0; k < newAmts[j].length; k++) {
+							if (newAmts[j][k] == 0)
+								continue;
+		
+							String set = pairList.get(k).getX();
+							String printing = pairList.get(k).getY();
+							String cardKey = Card.getCardKey(card.name, set, printing, null);
+							Card coolBasic = getCard(cardKey);
+							if (coolBasic == null) {
+								coolBasic = new Card();
+								coolBasic.name = card.name;
+								coolBasic.cardKey = cardKey;
+								coolBasic.set = set;
+								coolBasic.printing = printing;
+
+								add(coolBasic);
+							}
+							coolBasic.amounts[j] += newAmts[j][k];
+						}
+					}
+					cardList.remove(i);
 				}
-				cardList.remove(i);
 			}
 		}
 	}

--- a/libs/src/core/Deck.java
+++ b/libs/src/core/Deck.java
@@ -2,9 +2,11 @@ package core;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Map;
 
 import cardbuddies.Token;
 import cardbuddies.Transform;
+import helpers.Pair;
 
 public class Deck {
 	
@@ -68,6 +70,50 @@ public class Deck {
 		}
 	}
 	
+	public void Artify() {
+		Map<String, ArrayList<Pair<String, String>>> fullArtLands;
+		fullArtLands = Config.fullArtMap;
+		
+		for (int i = cardList.size() - 1; i >= 0; i-- ) {
+			Card card = cardList.get(i);
+
+			if(fullArtLands.containsKey(card.name)) {
+				ArrayList<Pair<String, String>> pairList = fullArtLands.get(card.name);
+				
+				int[][] newAmts = new int[card.amounts.length][pairList.size()];
+				
+				for(int j= 0; j< card.amounts.length; j++) {
+					for(int k=0; k < card.amounts[j]; k++) {
+						newAmts[j][(int) (Math.random() * pairList.size())]++;
+					}
+				}
+				
+				for (int j = 0; j < newAmts.length; j++) {
+					for (int k = 0; k < newAmts[j].length; k++) {
+						if (newAmts[j][k] == 0)
+							continue;
+	
+						String set = pairList.get(k).getX();
+						String printing = pairList.get(k).getY();
+						String cardKey = Card.getCardKey(card.name, set, printing, null);
+						Card coolBasic = getCard(cardKey);
+						if (coolBasic == null) {
+							coolBasic = new Card();
+							coolBasic.name = card.name;
+							coolBasic.cardKey = cardKey;
+							coolBasic.set = set;
+							coolBasic.printing = printing;
+
+							add(coolBasic);
+						}
+						coolBasic.amounts[j] += newAmts[j][k];
+					}
+				}
+				cardList.remove(i);
+			}
+		}
+	}
+
 	public void Coolify(){		
 		String[] basics = {"island","forest","mountain","swamp","plains"};
 		String[] coolSets = {"uh","guru","al","zen"};

--- a/libs/src/core/DeckMaker.java
+++ b/libs/src/core/DeckMaker.java
@@ -120,6 +120,7 @@ public class DeckMaker {
 		newDeck.backUrl = ReadLine(clientScanner);
 		newDeck.hiddenUrl = ReadLine(clientScanner);
 		boolean coolifyBasics = ReadLine(clientScanner).equals("true");
+		boolean artifyBasics = ReadLine(clientScanner).equals("true");
 		try{
 			newDeck.compressionLevel = Double.parseDouble(clientScanner.readLine());
 		}catch(Exception e){}
@@ -133,7 +134,12 @@ public class DeckMaker {
 		if(newDeck.cardList.size() + newDeck.transformList.size() == 0){ errorMessage = "Too few cards!"; }
 		if(newDeck.cardList.size() + newDeck.transformList.size() >= 150){ errorMessage = "Too many different cards!"; }
 		if(errorMessage == null){
-			if(coolifyBasics)newDeck.Coolify();
+			if(coolifyBasics){
+				newDeck.Coolify();
+			}
+			else if (artifyBasics){
+				newDeck.Artify();
+			}
 	
 			ImageUtils.DownloadImages(newDeck);
 			FrogUtils.Debug("Downloaded images, with " + newDeck.unknownCards.size() + " unknown");

--- a/libs/src/helpers/Pair.java
+++ b/libs/src/helpers/Pair.java
@@ -1,0 +1,29 @@
+package helpers;
+
+public class Pair <X, Y> {
+	
+	private X x;
+	private Y y;
+	
+	public Pair(X x, Y y) {
+		this.x = x;
+		this.y = y;
+	}
+	
+	public X getX() {
+		return x;
+	}
+	
+	public void setX(X x) {
+		this.x = x;
+	}
+	
+	public Y getY() {
+		return y;
+	}
+	
+	public void setY(Y y) {
+		this.y = y;
+	}
+
+}

--- a/libs/src/utils/FrogUtils.java
+++ b/libs/src/utils/FrogUtils.java
@@ -70,6 +70,13 @@ public class FrogUtils {
 		return "";
 	}
 	
+	public static boolean IsNullOrEmpty(String string){
+		if(string == null || string == ""){
+			return true;
+		}
+		return false;
+	}
+	
 	public static String ReplaceHardChars(String source){
 		for(String[] hardPair : Config.hardNameCharacters){
 			source = source.replaceAll("\\Q"+hardPair[0]+"\\E", hardPair[1]);

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"deckDir": "/datadrive/decks/",
 	"imageDir": "/datadrive/images/",
 	"setAssetDir": "/datadrive/setAssets/",
@@ -83,31 +83,36 @@
 		{
 			"landType" : "swamp",
 			"cards" : 	[	{"set" : "uh", "printings" : ["138"]},
-							{"set" : "zen", "printings" : ["260b", "261b", "262b", "263b", "264b"]}
+							{"set" : "bfz", "printings" : ["260b", "261b", "262b", "263b", "264b"]},
+							{"set" : "zen", "printings" : ["238", "239", "240", "241"]}
 						]
 		},
 		{
 			"landType" : "island",
 			"cards" : 	[	{"set" : "uh", "printings" : ["137"]},
+							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
 							{"set" : "zen", "printings" : ["234", "235", "236", "237"]}
 						]
 		},
 		{
 			"landType" : "mountain",
 			"cards" : 	[	{"set" : "uh", "printings" : ["139"]},
-							{"set" : "zen", "printings" : ["265b", "266b", "267b", "268b", "269b"]}
+							{"set" : "bfz", "printings" : ["265b", "266b", "267b", "268b", "269b"]},
+							{"set" : "zen", "printings" : ["242", "243", "244", "245"]}
 						]
 		},
 		{
 			"landType" : "plains",
 			"cards" : 	[	{"set" : "uh", "printings" : ["136"]},
-							{"set" : "zen", "printings" : ["250b", "251b", "252b", "253b", "254b"]}
+							{"set" : "bfz", "printings" : ["250b", "251b", "252b", "253b", "254b"]},
+							{"set" : "zen", "printings" : ["230", "231", "232", "233"]}
 						]	
 		},
 		{
 			"landType" : "forest",
 			"cards" : 	[	{"set" : "uh", "printings" : ["140"]},
-							{"set" : "zen", "printings" : ["270b", "271b", "272b", "273b", "274b"]}
+							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printings" : ["246", "247", "248", "249"]}
 						]
 		}
 	]

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -82,37 +82,37 @@
 	"fullArtLands": [
 		{
 			"landType" : "swamp",
-			"cards" : 	[	{"set" : "uh", "printings" : ["138"]},
-							{"set" : "bfz", "printings" : ["260b", "261b", "262b", "263b", "264b"]},
-							{"set" : "zen", "printings" : ["238", "239", "240", "241"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["138"]},
+							{"set" : "bfz", "printNumbers" : ["260b", "261b", "262b", "263b", "264b"]},
+							{"set" : "zen", "printNumbers" : ["238", "239", "240", "241"]}
 						]
 		},
 		{
 			"landType" : "island",
-			"cards" : 	[	{"set" : "uh", "printings" : ["137"]},
-							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printings" : ["234", "235", "236", "237"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["137"]},
+							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printNumbers" : ["234", "235", "236", "237"]}
 						]
 		},
 		{
 			"landType" : "mountain",
-			"cards" : 	[	{"set" : "uh", "printings" : ["139"]},
-							{"set" : "bfz", "printings" : ["265b", "266b", "267b", "268b", "269b"]},
-							{"set" : "zen", "printings" : ["242", "243", "244", "245"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["139"]},
+							{"set" : "bfz", "printNumbers" : ["265b", "266b", "267b", "268b", "269b"]},
+							{"set" : "zen", "printNumbers" : ["242", "243", "244", "245"]}
 						]
 		},
 		{
 			"landType" : "plains",
-			"cards" : 	[	{"set" : "uh", "printings" : ["136"]},
-							{"set" : "bfz", "printings" : ["250b", "251b", "252b", "253b", "254b"]},
-							{"set" : "zen", "printings" : ["230", "231", "232", "233"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["136"]},
+							{"set" : "bfz", "printNumbers" : ["250b", "251b", "252b", "253b", "254b"]},
+							{"set" : "zen", "printNumbers" : ["230", "231", "232", "233"]}
 						]	
 		},
 		{
 			"landType" : "forest",
-			"cards" : 	[	{"set" : "uh", "printings" : ["140"]},
-							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printings" : ["246", "247", "248", "249"]}
+			"printingInfo" :	[	{"set" : "uh", "printNumbers" : ["140"]},
+							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printNumbers" : ["246", "247", "248", "249"]}
 						]
 		}
 	]

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -82,37 +82,37 @@
 	"fullArtLands": [
 		{
 			"landType" : "swamp",
-			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["138"]},
-							{"set" : "bfz", "printNumbers" : ["260b", "261b", "262b", "263b", "264b"]},
-							{"set" : "zen", "printNumbers" : ["238", "239", "240", "241"]}
+			"cards" : 	[	{"set" : "uh", "printings" : ["138"]},
+							{"set" : "bfz", "printings" : ["260b", "261b", "262b", "263b", "264b"]},
+							{"set" : "zen", "printings" : ["238", "239", "240", "241"]}
 						]
 		},
 		{
 			"landType" : "island",
-			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["137"]},
-							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printNumbers" : ["234", "235", "236", "237"]}
+			"cards" : 	[	{"set" : "uh", "printings" : ["137"]},
+							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printings" : ["234", "235", "236", "237"]}
 						]
 		},
 		{
 			"landType" : "mountain",
-			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["139"]},
-							{"set" : "bfz", "printNumbers" : ["265b", "266b", "267b", "268b", "269b"]},
-							{"set" : "zen", "printNumbers" : ["242", "243", "244", "245"]}
+			"cards" : 	[	{"set" : "uh", "printings" : ["139"]},
+							{"set" : "bfz", "printings" : ["265b", "266b", "267b", "268b", "269b"]},
+							{"set" : "zen", "printings" : ["242", "243", "244", "245"]}
 						]
 		},
 		{
 			"landType" : "plains",
-			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["136"]},
-							{"set" : "bfz", "printNumbers" : ["250b", "251b", "252b", "253b", "254b"]},
-							{"set" : "zen", "printNumbers" : ["230", "231", "232", "233"]}
+			"cards" : 	[	{"set" : "uh", "printings" : ["136"]},
+							{"set" : "bfz", "printings" : ["250b", "251b", "252b", "253b", "254b"]},
+							{"set" : "zen", "printings" : ["230", "231", "232", "233"]}
 						]	
 		},
 		{
 			"landType" : "forest",
-			"printingInfo" :	[	{"set" : "uh", "printNumbers" : ["140"]},
-							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printNumbers" : ["246", "247", "248", "249"]}
+			"cards" : 	[	{"set" : "uh", "printings" : ["140"]},
+							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printings" : ["246", "247", "248", "249"]}
 						]
 		}
 	]

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -82,38 +82,37 @@
 	"fullArtLands": [
 		{
 			"landType" : "swamp",
-			"cards" : 	[	{"set" : "uh", "printings" : ["138"]},
-							{"set" : "bfz", "printings" : ["260b", "261b", "262b", "263b", "264b"]},
-							{"set" : "zen", "printings" : ["238", "239", "240", "241"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["138"]},
+							{"set" : "bfz", "printNumbers" : ["260b", "261b", "262b", "263b", "264b"]},
+							{"set" : "zen", "printNumbers" : ["238", "239", "240", "241"]}
 						]
 		},
 		{
 			"landType" : "island",
-			"cards" : 	[	{"set" : "uh", "printings" : ["137"]},
-							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printings" : ["234", "235", "236", "237"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["137"]},
+							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printNumbers" : ["234", "235", "236", "237"]}
 						]
 		},
 		{
 			"landType" : "mountain",
-			"cards" : 	[	{"set" : "uh", "printings" : ["139"]},
-							{"set" : "bfz", "printings" : ["265b", "266b", "267b", "268b", "269b"]},
-							{"set" : "zen", "printings" : ["242", "243", "244", "245"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["139"]},
+							{"set" : "bfz", "printNumbers" : ["265b", "266b", "267b", "268b", "269b"]},
+							{"set" : "zen", "printNumbers" : ["242", "243", "244", "245"]}
 						]
 		},
 		{
 			"landType" : "plains",
-			"cards" : 	[	{"set" : "uh", "printings" : ["136"]},
-							{"set" : "bfz", "printings" : ["250b", "251b", "252b", "253b", "254b"]},
-							{"set" : "zen", "printings" : ["230", "231", "232", "233"]}
+			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["136"]},
+							{"set" : "bfz", "printNumbers" : ["250b", "251b", "252b", "253b", "254b"]},
+							{"set" : "zen", "printNumbers" : ["230", "231", "232", "233"]}
 						]	
 		},
 		{
 			"landType" : "forest",
-			"cards" : 	[	{"set" : "uh", "printings" : ["140"]},
-							{"set" : "bfz", "printings" : ["270b", "271b", "272b", "273b", "274b"]},
-							{"set" : "zen", "printings" : ["246", "247", "248", "249"]}
+			"printingInfo" :	[	{"set" : "uh", "printNumbers" : ["140"]},
+							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "zen", "printNumbers" : ["246", "247", "248", "249"]}
 						]
 		}
-	]
-}
+	]}

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -78,5 +78,37 @@
 			"name": "tandemtactics",
 			"correction": "unisonstrike"
 		}
+	],
+	"fullArtLands": [
+		{
+			"landType" : "swamp",
+			"cards" : 	[	{"set" : "uh", "printings" : ["138"]},
+							{"set" : "zen", "printings" : ["260b", "261b", "262b", "263b", "264b"]}
+						]
+		},
+		{
+			"landType" : "island",
+			"cards" : 	[	{"set" : "uh", "printings" : ["137"]},
+							{"set" : "zen", "printings" : ["234", "235", "236", "237"]}
+						]
+		},
+		{
+			"landType" : "mountain",
+			"cards" : 	[	{"set" : "uh", "printings" : ["139"]},
+							{"set" : "zen", "printings" : ["265b", "266b", "267b", "268b", "269b"]}
+						]
+		},
+		{
+			"landType" : "plains",
+			"cards" : 	[	{"set" : "uh", "printings" : ["136"]},
+							{"set" : "zen", "printings" : ["250b", "251b", "252b", "253b", "254b"]}
+						]	
+		},
+		{
+			"landType" : "forest",
+			"cards" : 	[	{"set" : "uh", "printings" : ["140"]},
+							{"set" : "zen", "printings" : ["270b", "271b", "272b", "273b", "274b"]}
+						]
+		}
 	]
 }

--- a/settingsExample.json
+++ b/settingsExample.json
@@ -90,7 +90,7 @@
 		{
 			"landType" : "island",
 			"printingInfo" : 	[	{"set" : "uh", "printNumbers" : ["137"]},
-							{"set" : "bfz", "printNumbers" : ["270b", "271b", "272b", "273b", "274b"]},
+							{"set" : "bfz", "printNumbers" : ["255b", "256b", "257b", "258b", "259b"]},
 							{"set" : "zen", "printNumbers" : ["234", "235", "236", "237"]}
 						]
 		},
@@ -115,4 +115,4 @@
 							{"set" : "zen", "printNumbers" : ["246", "247", "248", "249"]}
 						]
 		}
-	]}
+]}

--- a/tests/test_fullart.js
+++ b/tests/test_fullart.js
@@ -1,0 +1,45 @@
+var tester = require('./frogtowntester.js');
+
+exports.RunTest = function(cb){
+	var expectedOutput = {
+		success: true,
+		successData: {
+			amtDecks: 1,
+			deckDescriptions: [
+				{
+					amt: 2,
+					names: {
+						"Swamp": 2
+					}
+				}
+			]
+		}
+	};
+
+	var input = {
+		req: {
+			body: {
+				decklist: "\n"
+				         +"1 swamp [pca]<142>\n"
+				         +"1 swamp\n",
+				sidelist: "",
+				backURL: '',
+				hiddenURL: '',
+				name: '',
+				coolify: false,
+				artify: true,
+				compression: 0.1
+			}
+		},
+		res: {},
+		attempt: 0,
+		isDraft: false
+	}
+
+	try{
+		tester.Test(input, expectedOutput, cb);
+	}catch(err){
+		console.log('Error: ' + err);
+		cb(false);
+	}
+}

--- a/tests/testrunner.js
+++ b/tests/testrunner.js
@@ -1,4 +1,5 @@
 var tests = [
+	'fullart',
 	'allbolts',
 	'characters',
 	'twofaced',

--- a/www/deckmaker.html
+++ b/www/deckmaker.html
@@ -36,7 +36,10 @@
 						<button type="button" class="btn btn-default" value="0.9">High Quality</button>
 					</div>
 					<div class="optionButtons">
-						<button type="button" class="btn coolify toggleButton btn-success"><span class="glyphicon glyphicon-ok"></span>&nbsp;Cool Basics</button>
+						<div class="btn-group landButtons">
+							<button type="button" class="btn coolify switchButton toggleButton btn-default"><span class="glyphicon glyphicon-ok"></span>&nbsp;Cool Basics</button>
+							<button type="button" class="btn artify switchButton toggleButton btn-success"><span class="glyphicon glyphicon-ok"></span>&nbsp;Full Art Basics</button>
+						</div>
 						<button type="button" class="btn sidebtn toggleButton btn-default"><span class="glyphicon glyphicon-ok"></span>&nbsp;Sideboard</button>
 						<button type="button" class="btn cmdbtn toggleButton btn-default"><span class="glyphicon glyphicon-ok"></span>&nbsp;Commander</button>
 					</div>

--- a/www/deckmaker.js
+++ b/www/deckmaker.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
-	var options = ['Cool Basic','Sideboard','Commander'];
-	var isActive = [true, false, false];
+	var options = ['Cool Basics', 'Full Art Basics', 'Sideboard','Commander'];
+	var isActive = [false, true, false, false];
 	var badLines = {};
 
 	var isChrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
@@ -31,6 +31,21 @@ $(document).ready(function(){
 		$('.qualityButtons button').removeClass('btn-info').addClass('btn-default');
 		$(event.currentTarget).addClass('btn-info').removeClass('btn-default');
 	});
+
+	$('.switchButton').click(function(event){
+		if($(event.currentTarget).hasClass('btn-default')) {
+			$('.switchButton').not(this).removeClass('btn-success').addClass('btn-default');
+		}
+
+		$('.switchButton').not(this).each(function() {
+			var btnText = $(this).text();
+			for(var i = 0; i < options.length; i++){
+				if(new RegExp(options[i]+'$').test(btnText)){
+					isActive[i] = $(this).hasClass('btn-success');
+				}
+			}	
+		});
+});
 
 	$('.toggleButton').click(function(event){
 		var src = $(event.currentTarget);
@@ -153,11 +168,11 @@ $(document).ready(function(){
 		var mainboard = BuildOneBoard(1, $('.userlist.mainboard').val());
 		boards.push(mainboard);
 
-		if(isActive[1]){
+		if(isActive[2]){
 			var sideboard = BuildOneBoard(2, $('.userlist.sideboard').val());
 			boards.push(sideboard);
 		}
-		if(isActive[2]){
+		if(isActive[3]){
 				var commander = BuildOneBoard(3, $('.userlist.commander').val());
 				boards.push(commander);
 		}
@@ -174,17 +189,18 @@ $(document).ready(function(){
 			$('.error').text('Too few cards!');
 		}else{
 			var list = 'MAINBOARD\n'+$('.userlist.mainboard').val();
-			if(isActive[1]){
+			if(isActive[2]){
 			        list += '\nSIDEBOARD\n'+$('.userlist.sideboard').val();
 			}
-			if(isActive[2]){
+			if(isActive[3]){
 			        list += '\nCOMMANDER\n'+$('.userlist.commander').val();
 			}
 
 			var backURL = $('#backURL').val().trim();
 			var hiddenURL = $('#hideURL').val().trim();
 			var deckName = $('#deckName').val().trim().length > 0?$('#deckName').val().trim():'frogtown_deck';
-			var coolify = $('#coolify').hasClass('btn-success');
+			var coolify = $('.coolify').hasClass('btn-success');
+			var artify = $('.artify').hasClass('btn-success');
 			var compression = $('.qualityButtons .btn-info').attr('value');
 			var name = $('#deckName').val().trim();
 
@@ -194,6 +210,7 @@ $(document).ready(function(){
 			reqobj.hiddenURL = hiddenURL;
 			reqobj.deckName = deckName;
 			reqobj.coolify = coolify;
+			reqobj.artify = artify;
 			reqobj.compression = compression;
 			reqobj.name = name;
 
@@ -330,8 +347,8 @@ $(document).ready(function(){
 
 	function UpdateSections(){
 		$(".optionalList").addClass("hidden");
-		if(isActive[1]) $("#sideboard").removeClass("hidden");
-		if(isActive[2]) $("#commander").removeClass("hidden");
+		if(isActive[2]) $("#sideboard").removeClass("hidden");
+		if(isActive[3]) $("#commander").removeClass("hidden");
 		UpdateTextareas()
 	}
 

--- a/www/help.html
+++ b/www/help.html
@@ -59,7 +59,7 @@
 				<p>Alternatively you can go to <a href="http://www.magiccards.info/sitemap.html" target="_blank">magiccards.info/sitemap.html</a> and select your set to see a full list of all printings in that set.</p>
 				<p><strong>Note that this feature requires a set to be specified, and when looking up printings on <a href="http://www.magiccards.info" target="_blank">magiccards.info</a> remember to use advanced search to specify your set.</strong></p>
 				<h3>Full Art Lands</h3>
-				<p>When you leave any basic lands with unspecified sets, the "Full Art Basics" feature wil distribute them randomly amongst the various full art printings.</p>
+				<p>When you leave any basic lands with unspecified sets, the "Full Art Basics" feature will distribute them randomly amongst the various printings with full artwork.</p>
 				<div class="spacer"></div>
 			</div>
 			<div class="stage" id="tokens">

--- a/www/help.html
+++ b/www/help.html
@@ -58,6 +58,8 @@
 				<p>To find the different printing numbers for the card you are examining, search for the card in your specific set on <a href="http://www.magiccards.info" target="_blank">magiccards.info</a> and look at the column in the top right of the page labeled "Printings". The numbers found here are the printing numbers that can selected.</p>
 				<p>Alternatively you can go to <a href="http://www.magiccards.info/sitemap.html" target="_blank">magiccards.info/sitemap.html</a> and select your set to see a full list of all printings in that set.</p>
 				<p><strong>Note that this feature requires a set to be specified, and when looking up printings on <a href="http://www.magiccards.info" target="_blank">magiccards.info</a> remember to use advanced search to specify your set.</strong></p>
+				<h3>Full Art Lands</h3>
+				<p>When you leave any basic lands with unspecified sets, the "Full Art Basics" feature wil distribute them randomly amongst the various full art printings.</p>
 				<div class="spacer"></div>
 			</div>
 			<div class="stage" id="tokens">


### PR DESCRIPTION
A feature that allows users to choose to have their basic lands randomly assigned a full art printing
@ToyDragon 

- Added button to deckmaker screen for "Full Art Basics".  Selected by default
- Allow "Full Art Basics" or "Cool Basics" to be selected, not both
- Added list of full art printing by land type and set to settings.json.  **Committed as part of settingsExample.json**
- Added FullArtMap which gets loaded with printing config data
- Added generic Pair<X,Y> object.  Used to pair a set and print number when loading FullArtMap
- Added Deck.Artify() which randomly chooses a full art printing for each basic land
- Added IsNullOrEmpty(String string) to FrogUtils.java.  Used in Artify() to safely determine if a set or printing has already been specified by the user
- Added Full Art Lands subsection the printing section of the help page describing this feature
- Added a very simple test which hits Artify() and verifies having a mixture of lands with no printing specified and lands with printing specified does not break artify

Note: Amonkhet (released end of April) is rumored to have a full art lands, these can be added by updating the config in settings.json